### PR TITLE
Fix ImportError if sqlalchemy not installed

### DIFF
--- a/spicedham/gottaimportthemall.py
+++ b/spicedham/gottaimportthemall.py
@@ -1,4 +1,8 @@
 import spicedham.bayes
 import spicedham.digitdestroyer
 import spicedham.nonsensefilter
-from spicedham.sqlalchemywrapper import SqlAlchemyWrapper
+
+try:
+    from spicedham.sqlalchemywrapper import SqlAlchemyWrapper
+except ImportError:
+    pass


### PR DESCRIPTION
If sqlalchemy isn't installed, this would try to import the sqlalchemy
wrapper and then kick up an ImportError.

This changes it so that if there's an ImportError, it gets ignored.

r?
